### PR TITLE
Fix GL_INT_2_10_10_10_REV sample

### DIFF
--- a/samples/gl-330-buffer-type.cpp
+++ b/samples/gl-330-buffer-type.cpp
@@ -28,7 +28,7 @@ namespace
 			x(int(511.0f * x)),
 			y(int(511.0f * y)),
 			z(int(511.0f * z)),
-			w(0)
+			w(1)
 		{}
 
 		operator glm::vec3()
@@ -234,7 +234,7 @@ bool initVertexArray()
 
 	glBindVertexArray(VertexArrayName[buffer::RGB10A2]);
 		glBindBuffer(GL_ARRAY_BUFFER, BufferName[buffer::RGB10A2]);
-		glVertexAttribPointer(glf::semantic::attr::POSITION, 4, GL_INT_2_10_10_10_REV, GL_FALSE, sizeof(i10i10i10i2), GLF_BUFFER_OFFSET(0));
+		glVertexAttribPointer(glf::semantic::attr::POSITION, 4, GL_INT_2_10_10_10_REV, GL_TRUE, sizeof(i10i10i10i2), GLF_BUFFER_OFFSET(0));
 		glBindBuffer(GL_ARRAY_BUFFER, 0);
 
 		glEnableVertexAttribArray(glf::semantic::attr::POSITION);


### PR DESCRIPTION
Hello.. 

Here are some clarifications on GL_INT_2_10_10_10_REV:

10 bits means the following range of values [0..0x3ff], for signed values (GL_INT_...) we have 2 ranges actually: positive [0, 0x1ff] and negative [0x200, 0x3ff] in reverse order (0x3ff is -1, 0x200 is -512).

For normalized GL_INT_2_10_10_10_REV format (fourth parameter in glVertexAttribPointer) all values are scaled to [-1.0f, 1.0f] range, so minimal negative value 0x200 relates to -1, and maximum positive value 0x1ff relates to 1. And vertex coordinates [-1, 1] should be [0x200, 0x1ff].

For not-normalized: 0x200 is -512, 0x1ff is 511.. so vertex coordinates [-1,1] should be [0x3ff, 0x001].

Your conversion "int(511*x)" for coordinates in range [-1, 1] produces values for normalized format, so you just need to set normalized=GL_TRUE in glVertexAttribPointer to fix displaying.

Also need to set up w=1 to avoid bad results after MVP multiplication.

Hope it helps.. And thanks for great project!
