### PR TITLE
Update glsl-cast-fail.vert

### DIFF
--- a/data/gl-320/glsl-cast-fail.vert
+++ b/data/gl-320/glsl-cast-fail.vert
@@ -21,7 +21,7 @@ out block
 
 void main()
 {
-	lowp int Count = lowp int(COUNT);
+	lowp int Count = int(COUNT);
 
 	for(lowp int i = 0; i < Count; ++i)
 		Out.Lumimance[i] = vec4(1.0) / vec4(COUNT);


### PR DESCRIPTION
lowp int(COUNT) is not a valid casting to lowp int, int(COUNT) will be sufficient.

Thanks,
-Diego
