### PR TITLE
Update buffer-storage.vert

### DIFF
--- a/data/gl-440/buffer-storage.vert
+++ b/data/gl-440/buffer-storage.vert
@@ -15,7 +15,7 @@ struct vertex
 	vec2 Texcoord;
 };
 
-layout(binding = VERTEX) buffer mesh
+layout(std430, binding = VERTEX) buffer mesh
 {
 	vertex Vertex[];
 } Mesh;


### PR DESCRIPTION
Shared qualifier is the default one.  Shared behave the same way as packed, which give the freedom to the driver to rearrange, compact or otherwise mess with the layout of the buffer content, with two condition the process it’s consistent, and doesn't remove any members. The application is assuming that std430 is the default one.
