### PR TITLE
Fix gl-320 primitive-point-quad vertex shader

### DIFF
--- a/data/gl-320/primitive-point-quad.vert
+++ b/data/gl-320/primitive-point-quad.vert
@@ -14,6 +14,12 @@ out block
 	vec4 Color;
 } Out;
 
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+
 void main()
 {
 	Out.Color = Color;


### PR DESCRIPTION
From section 7.1 (Built-In Language Variables) of the GLSL 4.10  spec:

     "If multiple shaders using members of a built-in block belonging
     to the same interface are linked together in the same program,
     they must all redeclare the built-in block in the same way, as
     described in section 4.3.7 "Interface Blocks" for interface
     block matching, or a link error will result.  It will also be a
     link error if some shaders in a program redeclare a specific
     built-in interface block while another shader in that program
     does not redeclare that interface block yet still uses a member
     of that interface block."

This fixes the test for Mesa drivers which seem to be the only drivers that follow the spec.