### PR TITLE
redeclaration of built-in name

### DIFF
--- a/data/gl-320/fbo-blend-points.frag
+++ b/data/gl-320/fbo-blend-points.frag
@@ -4,8 +4,6 @@ precision highp float;
 precision highp int;
 layout(std140, column_major) uniform;
 
-in vec2 gl_PointCoord;
-
 in block
 {
 	vec4 Color;

--- a/data/gl-320/fbo-srgb-blend.frag
+++ b/data/gl-320/fbo-srgb-blend.frag
@@ -4,8 +4,6 @@ precision highp float;
 precision highp int;
 layout(std140, column_major) uniform;
 
-in vec2 gl_PointCoord;
-
 out vec4 Color;
 
 in block

--- a/data/gl-320/primitive-sprite.frag
+++ b/data/gl-320/primitive-sprite.frag
@@ -6,8 +6,6 @@ layout(std140, column_major) uniform;
 
 uniform sampler2D Diffuse;
 
-in vec2 gl_PointCoord;
-
 in block
 {
 	vec3 Color;

--- a/data/gl-400/fbo-multisample-mask.frag
+++ b/data/gl-400/fbo-multisample-mask.frag
@@ -11,7 +11,6 @@ in block
 	vec2 Texcoord;
 } In;
 
-out int gl_SampleMask[];
 out vec4 Color;
 
 void main()

--- a/data/gl-460/glsl-vote.frag
+++ b/data/gl-460/glsl-vote.frag
@@ -8,8 +8,6 @@ precision highp float;
 precision highp int;
 layout(std140, column_major) uniform;
 
-in vec2 gl_PointCoord;
-
 layout(binding = DIFFUSE) uniform sampler2D Diffuse;
 
 layout(location = FRAG_COLOR, index = 0) out vec4 Color;


### PR DESCRIPTION
Hi, I read the GLSL spec and there's no reference shows 'gl_SampleMask' and 'gl_PointCoord' can be redeclared.
Remove them to follow the GLSL spec and have compatibility with the CTS TEST which against redeclare built-in name :)