### PR TITLE
gl_PerVertex redeclare not support under version 410

### DIFF
--- a/data/gl-320/glsl-builtin-blocks.vert
+++ b/data/gl-320/glsl-builtin-blocks.vert
@@ -18,11 +18,6 @@ out block
 	flat int Instance;
 } Out;
 
-out gl_PerVertex
-{
-	vec4 gl_Position;
-};
-
 void main()
 {	
 	Out.Texcoord = Texcoord;

--- a/data/gl-320/primitive-point-quad.geom
+++ b/data/gl-320/primitive-point-quad.geom
@@ -17,18 +17,6 @@ uniform mat4 MVP;
 uniform mat4 MV;
 uniform vec3 CameraPosition;
 
-in gl_PerVertex
-{
-	vec4 gl_Position;
-	float gl_PointSize;
-} gl_in[];
-
-out gl_PerVertex
-{
-	vec4 gl_Position;
-	float gl_PointSize;
-};
-
 in block
 {
 	vec4 Color;

--- a/data/gl-400/buffer-uniform-array.vert
+++ b/data/gl-400/buffer-uniform-array.vert
@@ -15,11 +15,6 @@ uniform transform
 	mat4 MVP;
 } Transform[2];
 
-out gl_PerVertex
-{
-	vec4 gl_Position;
-};
-
 out block
 {
 	flat int Instance;

--- a/data/gl-400/multi-draw-indirect.vert
+++ b/data/gl-400/multi-draw-indirect.vert
@@ -30,11 +30,6 @@ layout(location = POSITION) in vec2 Position;
 layout(location = TEXCOORD) in vec2 Texcoord;
 layout(location = DRAW_ID) in int DrawID;
 
-out gl_PerVertex
-{
-	vec4 gl_Position;
-};
-
 out block
 {
 	vec2 Texcoord;

--- a/data/gl-400/texture-cube.vert
+++ b/data/gl-400/texture-cube.vert
@@ -18,11 +18,6 @@ const vec3 ConstNormal = vec3(0, 0, 1);
 
 layout(location = POSITION) in vec2 Position;
 
-out gl_PerVertex
-{
-	vec4 gl_Position;
-};
-
 out block
 {
 	vec3 Reflect;

--- a/data/gl-400/transform-stream.geom
+++ b/data/gl-400/transform-stream.geom
@@ -20,13 +20,6 @@ out block
 	layout(stream = 0) vec4 Color;
 } Out;
 
-out gl_PerVertex 
-{
-	vec4 gl_Position;
-	float gl_PointSize;
-	float gl_ClipDistance[];
-};
-
 void main()
 {
 	for(int i = 0; i < gl_in.length(); ++i)


### PR DESCRIPTION
Description:
===

Follow GLSL spec, built-in block "gl_PerVertex" redeclare is not support under version 410.

GLSL 410 spec:
>The gl_PerVertex block can be redeclared in a shader to explicitly indicate what subset of the fixed
pipeline interface will be used. This is necessary to establish the interface between multiple programs.

This section never appeared in a previous GLSL release version. Or you have to require extension ARB_separate_shader_objects in shader source, and make sure the version can't under 140.